### PR TITLE
Add exception for drive letters to Link redact

### DIFF
--- a/src/component/Message.tsx
+++ b/src/component/Message.tsx
@@ -5,6 +5,8 @@ import MessageService from '../service/MessageService';
 import ChatStamp from './ChatStamp';
 import ChatUser from './ChatUser';
 
+const driveLetterRegex = new RegExp('^[a-z]:', 'i');
+
 export default function Message({ data, useBlacklist = true, messageKey = null }) {
     if (useBlacklist == true && ConfigService.config.blackList.includes(data.context["display-name"])) {
         return null;
@@ -20,13 +22,17 @@ export default function Message({ data, useBlacklist = true, messageKey = null }
         return true;
     }
 
+    const isDriveLetter = (string) => {
+        return driveLetterRegex.test(string);
+    }
+
     const applyFilters = (message) => {
         console.log(message);
         let segments = message.split(/\s+/);
         let result = [];
         let idx = 0;
         for(let segment of segments) {
-            if(true == isUrl(segment)) {
+            if(isUrl(segment) && !isDriveLetter(segment)) {
                 result.push(<span className={'external-link'} onClick={() => { openLink(segment) }} key={"l-" + idx}>[link]</span>);
             } else {
                 result.push(segment+" ");


### PR DESCRIPTION
Ich habe heute mitbekommen, wie Aza beim abhandeln einer Frage bezüglich Windows Laufwerksbuchstaben plötzlich meinte "Oh, jetzt tut mein Fragentool komische Dinge...". Zuerst aus Neugier habe ich rein geschaut, was da sein könnte und habe festgestellt, dass die Linkfilter in diesem Sonderfall in die Quere kommen. Eine Nachricht mit der Struktur

```
{
  context: {
    'display-name': 'test user',
    'tmi-sent-ts': '1628013659'
   },
   message: 'test C: c: a: z: Z: z.:dddfddd abcd: https://www.twitch.tv/pcdocberlin http://google.com tcp://127.0.0.1 http://192.168.1.2:443 http://my.host:8080'
}
```
produziert im Moment eine komplett gefilterte Nachricht:
<img width="1136" alt="Bildschirmfoto 2021-08-03 um 21 46 36" src="https://user-images.githubusercontent.com/5060150/128076774-d2a6e5ae-4e70-459b-953d-58eb41138027.png">

mein Vorschlag, um diesen konkreten Fall zu verbessern wäre, für erkannte URLs (und Laufwerke als URLs zu erkennen schien in Javascript gewolltes Verhalten zu sein), eine weitere Prüfung auf Laufwerksbuchstaben durchzuführen und diese zu erlauben:
<img width="1136" alt="Bildschirmfoto 2021-08-03 um 21 46 06" src="https://user-images.githubusercontent.com/5060150/128076939-627645c7-b258-4286-8ea9-43877e182641.png">

Wenn es weitere Fragen, Anmerkungen oder Diskussionsbedarf an dieser Änderung gibt, können wir gerne darüber reden.

Gruß,
Julian aka oxygen0211